### PR TITLE
Modify aiopg dependency to suit pipenv naming requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     python_requires=">=3.5",
     install_requires=[
         "sqlalchemy>=1.3.0",
-        "aiopg@git://github.com/gastromatic/aiopg@7c4d828",
+        "aiopg@git+https://github.com/gastromatic/aiopg@7c4d828",
         "pydantic>=1.2",
     ],
     license="MIT",


### PR DESCRIPTION
I was unable to install this package using pipenv (version 2020.8.13) as a package manager (instead of running setup.py). This pull request fixes this issue.