### PR TITLE
fix: align renovate config with shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,5 @@
 {
   "extends": [
-    "github>gastromatic/renovate-config"
-  ],
-  "reviewers": [
-    "team:business-system-integrations"
-  ],
-  "reviewersSampleSize": 2
+    "github>gastromatic/bsi-renovate-config"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "github>gastromatic/renovate-config"
   ],
   "reviewers": [
-    "team:interfaces"
+    "team:business-system-integrations"
   ],
   "reviewersSampleSize": 2
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "github>gastromatic/renovate-config"
+  ],
+  "reviewers": [
+    "team:interfaces"
+  ],
+  "reviewersSampleSize": 2
+}


### PR DESCRIPTION
- [x] fix renovate to use default config which has weekly settings https://github.com/gastromatic/renovate-config/blob/main/default.json